### PR TITLE
Fix version conflicts caused by PR#409

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.14.7" /> 
     <PackageReference Include="Bogus" Version="31.0.3" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0" />
@@ -28,6 +28,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
-    <PackageReference Include="Microsoft.CodeCoverage" Version="16.7.1" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="16.10.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.NET.Test.Sdk from 16.7.1 to 16.10.0. [(PR#409)](https://github.com/mgnz/mgnz.squidex.cli/pull/409).
Hope this fix can help you.

Best regards,
sucrose